### PR TITLE
Update tagesschau.de.xml

### DIFF
--- a/src/chrome/content/rules/tagesschau.de.xml
+++ b/src/chrome/content/rules/tagesschau.de.xml
@@ -1,8 +1,6 @@
 <!--
 	Non-functional subdomains:
 		- atlas		(connection refused)
-		- mail		(¹, CN: www.mailer-service.de, mailer-service.de)
-		- karten	(¹, CN: *.akamaihd.net)
 
 	¹ Hostname mismatch
 
@@ -23,16 +21,19 @@
 			- wetter and www from de.sitestat.com *
 			- wetter and www from gsea.ivwbox.de *
 			- wetter and www from tagessch.ivwbox.de *
+			- www from ts.flyp.tv *
 
 	* Secured by us
 
 -->
 <ruleset name="tagesschau.de (partial)">
 	<target host=       "tagesschau.de"/>
-	<target host=   "www.tagesschau.de"/>
-	<target host=  "meta.tagesschau.de"/>
-	<target host=  "wahl.tagesschau.de"/>
-	<target host="wetter.tagesschau.de"/>
+	<target host=    "www.tagesschau.de"/>
+	<target host= "karten.tagesschau.de"/>
+	<target host=  "media.tagesschau.de"/>
+	<target host=   "meta.tagesschau.de"/>
+	<target host=   "wahl.tagesschau.de"/>
+	<target host= "wetter.tagesschau.de"/>
 
 
 	<!--	Not secured by server:
@@ -40,10 +41,6 @@
 	<!--securecookie host="^www\.tagesschau\.de$" name="X-Mapping-[a-z]+$" /-->
 
 	<securecookie host="^www\.tagesschau\.de$" name=".+" />
-
-	<exclusion pattern="^http://wetter\.tagesschau\.de/unwetter" />
-
-		<test url="http://wetter.tagesschau.de/unwetter" />
 
 	<rule from="^http://tagesschau\.de/"
 		to="https://www.tagesschau.de/"/>


### PR DESCRIPTION
- Exception for https://wetter.tagesschau.de/unwetter/ no longer needed, former mixed-content script has been correctly linked
- Add karten subdomain, cert is correct now, used e.g. for map on https://wetter.tagesschau.de/deutschland/wetterstationen/
- Add media subdomain used for videos, e.g. linked on https://www.tagesschau.de/multimedia/startseite/index.html
- Remove comment for no longer existing mail subdomain